### PR TITLE
Upgrade eslint-config-nightmare-mode to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/jonathanKingston/eslint-config-ember#readme",
   "dependencies": {
-    "eslint-config-nightmare-mode": "^0.2.1",
+    "eslint-config-nightmare-mode": "~0.3.0",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Caret doesn't work very well for 0.x versions since it reference the left most non-zero version number. `^0.2.1` will not automatically load `0.3.0`.