### PR TITLE
Allow function expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ var overrides = {
     "func-names": 0,
     "no-invalid-this": 0,
     "prefer-template": 0,
-    "no-underscore-dangle": 0
+    "no-underscore-dangle": 0,
+    "no-restricted-syntax": [2, "WithStatement"]
   }
 };
 


### PR DESCRIPTION
Allows Ember developers to do standard Ember things like:

```javascript
Router.map(function() { // currently causes: Using "FunctionExpression" is not allowed. (no-restricted-syntax)
  this.route('foo');
});
```

Arrow syntax is not an option in these cases because Ember needs to set the context.