### PR TITLE
Update to latest ESLint and nightmare-mode.

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,3 +1,35 @@
 var fs = require('fs');
+var path = require('path');
 var config = require('./index');
-fs.writeFile("build/eslint.json", JSON.stringify(config), {encoding: 'utf8'});
+
+
+var dir = 'build';
+var jsonFile = 'eslint.json';
+var fullPath = path.join(dir, jsonFile);
+
+
+function justThrowErrors(err) { if(err) { throw err; } }
+
+
+function makeDir(dir, callback) {
+  fs.mkdir(dir, (err) => {
+    if (err) { throw err; }
+
+    callback();
+  });
+}
+
+
+function writeJson(jsonPath) {
+  fs.writeFile(jsonPath, JSON.stringify(config), { encoding: 'utf8' }, justThrowErrors);
+}
+
+
+// We can't write the file if we don't have the `build` directory.
+fs.stat(dir, (err) => {
+  if (err) {
+    makeDir(dir, () => writeJson(fullPath));
+  } else {
+    writeJson(fullPath);
+  }
+})

--- a/index.js
+++ b/index.js
@@ -2,23 +2,23 @@ var assign = require('object-assign');
 var config = require('eslint-config-nightmare-mode/browser');
 // Ember specific overrides
 var overrides = {
- "rules": {
-   "new-cap": [0,
+  "rules": {
+    "new-cap": [0,
       {
         "capIsNewExceptions": [
-            "Array",
-            "Boolean",
-            "Date",
-            "Error",
-            "Function",
-            "Number",
-            "Object",
-            "RegExp",
-            "String",
-            "Symbol",
-  
-            "Ember",
-            "A"
+          "Array",
+          "Boolean",
+          "Date",
+          "Error",
+          "Function",
+          "Number",
+          "Object",
+          "RegExp",
+          "String",
+          "Symbol",
+
+          "Ember",
+          "A"
         ]
       }
     ],

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   },
   "homepage": "https://github.com/jonathanKingston/eslint-config-ember#readme",
   "dependencies": {
-    "eslint-config-nightmare-mode": "^0.2.1",
+    "eslint-config-nightmare-mode": "^2.3.0",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "chai": "^2.3.0",
-    "eslint": "^1.4.1",
+    "eslint": "^2.4.0",
     "mocha": "^2.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-ember",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Linting defaults to match Ember",
   "main": "index.js",
   "scripts": {

--- a/tests/fixtures/out/ember.js
+++ b/tests/fixtures/out/ember.js
@@ -2,10 +2,19 @@
   {
     "ruleId": "no-undef",
     "severity": 2,
-    "message": "\"Ember\" is not defined.",
+    "message": "'Ember' is not defined.",
     "line": 1,
     "column": 1,
     "nodeType": "Identifier",
+    "source": "Ember.A([1,2,3]);"
+  },
+  {
+    "ruleId": "no-magic-numbers",
+    "severity": 2,
+    "message": "No magic number: 1",
+    "line": 1,
+    "column": 10,
+    "nodeType": "Literal",
     "source": "Ember.A([1,2,3]);"
   },
   {
@@ -15,6 +24,22 @@
     "line": 1,
     "column": 11,
     "nodeType": "Punctuator",
+    "source": "Ember.A([1,2,3]);",
+    "fix": {
+      "range": [
+        11,
+        11
+      ],
+      "text": " "
+    }
+  },
+  {
+    "ruleId": "no-magic-numbers",
+    "severity": 2,
+    "message": "No magic number: 2",
+    "line": 1,
+    "column": 12,
+    "nodeType": "Literal",
     "source": "Ember.A([1,2,3]);"
   },
   {
@@ -24,6 +49,22 @@
     "line": 1,
     "column": 13,
     "nodeType": "Punctuator",
+    "source": "Ember.A([1,2,3]);",
+    "fix": {
+      "range": [
+        13,
+        13
+      ],
+      "text": " "
+    }
+  },
+  {
+    "ruleId": "no-magic-numbers",
+    "severity": 2,
+    "message": "No magic number: 3",
+    "line": 1,
+    "column": 14,
+    "nodeType": "Literal",
     "source": "Ember.A([1,2,3]);"
   }
 ]

--- a/tests/fixtures/out/index.js
+++ b/tests/fixtures/out/index.js
@@ -18,6 +18,15 @@
     "source": "var spoon = 'thhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhiiisssss iss longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg';"
   },
   {
+    "ruleId": "no-var",
+    "severity": 2,
+    "message": "Unexpected var, use let or const instead.",
+    "line": 1,
+    "column": 1,
+    "nodeType": "VariableDeclaration",
+    "source": "var spoon = 'thhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhiiisssss iss longgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg';"
+  },
+  {
     "ruleId": "no-console",
     "severity": 2,
     "message": "Unexpected console statement.",
@@ -29,10 +38,17 @@
   {
     "ruleId": "spaced-comment",
     "severity": 2,
-    "message": "Expected space or tab after // in comment.",
+    "message": "Expected space or tab after '//' in comment.",
     "line": 3,
     "column": 1,
     "nodeType": "Line",
-    "source": "//thig"
+    "source": "//thig",
+    "fix": {
+      "range": [
+        190,
+        190
+      ],
+      "text": " "
+    }
   }
 ]


### PR DESCRIPTION
Resolves #6. Note, however, that this does _not_ resolve the estraverse-fb issue that crops up in many tools which _also_ use this because of the babel-eslint dependency. Those tools need to update to `babel-eslint` at 6.0.0-beta.6 or higher.
